### PR TITLE
Fix ToolContext metadata and stdio request concurrency

### DIFF
--- a/sdk/server/include/cxxmcp/server/context.hpp
+++ b/sdk/server/include/cxxmcp/server/context.hpp
@@ -33,10 +33,20 @@ struct ToolContext : SessionContext {
 
   /// JSON arguments supplied with the tool call.
   protocol::Json arguments = protocol::Json::object();
+  /// Optional `tools/call._meta` metadata supplied with the tool call.
+  std::optional<protocol::Json> meta;
   /// Optional task request metadata supplied with the tool call.
   std::optional<protocol::TaskRequestParameters> task;
   /// Cooperative cancellation token for task-aware executions.
   CancellationToken cancellation;
+
+  /// @brief Return the `tools/call._meta.progressToken`, when present.
+  std::optional<protocol::ProgressToken> progress_token() const {
+    if (!meta.has_value()) {
+      return std::nullopt;
+    }
+    return protocol::meta_progress_token(*meta);
+  }
 
   /// @brief Convenience check for cancellation-aware handlers.
   bool cancelled() const noexcept { return cancellation.cancelled(); }

--- a/sdk/server/include/cxxmcp/server/stdio_transport.hpp
+++ b/sdk/server/include/cxxmcp/server/stdio_transport.hpp
@@ -35,10 +35,12 @@ namespace mcp::server {
 /// mcp::transport::ServerStdioTransport with ServerPeer/Service, or a
 /// platform-owned process/pipe transport.
 ///
-/// The server stdio loop handles one inbound line at a time and writes the
-/// corresponding response before reading the next request. It therefore has no
-/// concrete in-flight request registry; duplicate in-flight request-id
-/// validation is enforced by asynchronous peer/native/adapter layers.
+/// After the initialize handshake completes, request handlers may run
+/// concurrently so long-running tool calls do not block later inbound messages.
+/// Responses are serialized with their JSON-RPC ids and may be written in
+/// completion order. Initialization, notification handling, malformed input,
+/// and duplicate in-flight request-id checks remain serialized by the read
+/// loop.
 class StdioTransport final : public Transport {
  public:
   /// @brief Construct a transport using std::cin and std::cout.
@@ -51,8 +53,8 @@ class StdioTransport final : public Transport {
   StdioTransport(std::istream& input, std::ostream& output);
 
   /// @brief Run the stdio message loop.
-  /// @param handler Required request handler invoked synchronously on the
-  /// start() caller's thread.
+  /// @param handler Required request handler. Initialize requests run on the
+  /// start() caller's thread; later requests may run on worker threads.
   /// @param notification_handler Optional notification handler invoked
   /// synchronously on the start() caller's thread.
   /// @return core::Unit after clean EOF or stop(), or a core::Error for

--- a/sdk/server/src/registry.cpp
+++ b/sdk/server/src/registry.cpp
@@ -390,6 +390,7 @@ core::Result<protocol::ToolResult> ToolRegistry::call(
   context.transport = session_context.transport;
   context.transport_lifetime = session_context.transport_lifetime;
   context.arguments = std::move(call.arguments);
+  context.meta = std::move(call.meta);
   context.task = std::move(call.task);
   context.cancellation = std::move(cancellation);
   const auto result = entry.handler(context);

--- a/sdk/server/src/stdio_transport.cpp
+++ b/sdk/server/src/stdio_transport.cpp
@@ -6,8 +6,13 @@
 #include <iostream>
 #include <optional>
 #include <string>
+#include <system_error>
+#include <thread>
+#include <type_traits>
+#include <unordered_set>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #ifndef _WIN32
 #include <pthread.h>
@@ -142,6 +147,19 @@ bool is_allowed_before_initialized(const protocol::JsonRpcRequest& request) {
          request.method == protocol::PingMethod;
 }
 
+std::string request_id_to_string(const protocol::RequestId& request_id) {
+  return std::visit(
+      [](const auto& value) -> std::string {
+        using Value = std::decay_t<decltype(value)>;
+        if constexpr (std::is_same_v<Value, std::string>) {
+          return std::string("s:") + value;
+        } else {
+          return std::string("i:") + std::to_string(value);
+        }
+      },
+      request_id);
+}
+
 }  // namespace
 
 StdioTransport::StdioTransport() : StdioTransport(std::cin, std::cout) {}
@@ -165,6 +183,68 @@ core::Result<core::Unit> StdioTransport::start(
 
   initialized_ = false;
   running_.store(true, std::memory_order_release);
+
+  std::mutex worker_state_mutex;
+  std::unordered_set<std::string> in_flight_request_ids;
+  std::optional<core::Error> worker_error;
+  std::vector<std::thread> workers;
+
+  auto record_worker_error = [&](core::Error error) {
+    std::lock_guard lock(worker_state_mutex);
+    if (!worker_error.has_value()) {
+      worker_error = std::move(error);
+    }
+    running_.store(false, std::memory_order_release);
+  };
+
+  auto wait_for_workers = [&]() {
+    for (auto& worker : workers) {
+      if (worker.joinable()) {
+        worker.join();
+      }
+    }
+  };
+
+  auto handle_request = [&](protocol::JsonRpcRequest request,
+                            SessionContext context) {
+    core::Result<protocol::JsonRpcResponse> response;
+    try {
+      response = handler(request, context);
+    } catch (const std::exception& ex) {
+      response = mcp::core::unexpected(errors::handler_failed(ex.what()));
+    } catch (...) {
+      response = mcp::core::unexpected(errors::handler_unknown_exception());
+    }
+    if (!response) {
+      response = protocol::make_error_response(
+          std::optional<protocol::RequestId>{request.id},
+          protocol::make_error(
+              response.error().code, response.error().message,
+              response.error().detail.empty()
+                  ? std::nullopt
+                  : std::optional<protocol::Json>{response.error().detail}));
+    }
+
+    if (request.method == protocol::InitializeMethod) {
+      std::lock_guard lock(client_capabilities_mutex_);
+      if (request.params.is_object() &&
+          request.params.contains("capabilities")) {
+        client_capabilities_ = protocol::client_capabilities_from_json(
+            request.params.at("capabilities"));
+      } else {
+        client_capabilities_.reset();
+      }
+    }
+
+    core::Result<core::Unit> written;
+    {
+      std::lock_guard lock(output_mutex_);
+      written = write_response(*output_, *response);
+    }
+    if (!written) {
+      record_worker_error(written.error());
+    }
+  };
 
   std::string line;
   while (running_.load(std::memory_order_acquire) &&
@@ -257,47 +337,62 @@ core::Result<core::Unit> StdioTransport::start(
       }
       continue;
     }
-    core::Result<protocol::JsonRpcResponse> response;
-    try {
-      response = handler(*request, context);
-    } catch (const std::exception& ex) {
-      response = mcp::core::unexpected(errors::handler_failed(ex.what()));
-    } catch (...) {
-      response = mcp::core::unexpected(errors::handler_unknown_exception());
-    }
-    if (!response) {
-      response = protocol::make_error_response(
-          std::optional<protocol::RequestId>{request->id},
-          protocol::make_error(
-              response.error().code, response.error().message,
-              response.error().detail.empty()
-                  ? std::nullopt
-                  : std::optional<protocol::Json>{response.error().detail}));
+
+    if (request->method == protocol::InitializeMethod || !initialized_) {
+      handle_request(*request, context);
+      continue;
     }
 
-    if (request->method == protocol::InitializeMethod) {
-      std::lock_guard lock(client_capabilities_mutex_);
-      if (request->params.is_object() &&
-          request->params.contains("capabilities")) {
-        client_capabilities_ = protocol::client_capabilities_from_json(
-            request->params.at("capabilities"));
-      } else {
-        client_capabilities_.reset();
-      }
-    }
-
-    core::Result<core::Unit> written;
+    const auto request_key = request_id_to_string(request->id);
+    bool duplicate_request = false;
     {
-      std::lock_guard lock(output_mutex_);
-      written = write_response(*output_, *response);
+      std::lock_guard lock(worker_state_mutex);
+      const auto [_, inserted] = in_flight_request_ids.insert(request_key);
+      duplicate_request = !inserted;
     }
-    if (!written) {
+    if (duplicate_request) {
+      core::Result<core::Unit> written;
+      {
+        std::lock_guard output_lock(output_mutex_);
+        written = write_error(
+            *output_, static_cast<int>(protocol::ErrorCode::InvalidRequest),
+            "duplicate in-flight request id", request->id);
+      }
+      if (!written) {
+        running_.store(false, std::memory_order_release);
+        wait_for_workers();
+        return mcp::core::unexpected(written.error());
+      }
+      continue;
+    }
+
+    try {
+      workers.emplace_back(
+          [&, request_copy = *request, context, request_key]() mutable {
+            handle_request(std::move(request_copy), std::move(context));
+            {
+              std::lock_guard lock(worker_state_mutex);
+              in_flight_request_ids.erase(request_key);
+            }
+          });
+    } catch (const std::system_error& ex) {
+      {
+        std::lock_guard lock(worker_state_mutex);
+        in_flight_request_ids.erase(request_key);
+      }
       running_.store(false, std::memory_order_release);
-      return mcp::core::unexpected(written.error());
+      wait_for_workers();
+      return mcp::core::unexpected(make_transport_error(
+          static_cast<int>(protocol::ErrorCode::InternalError),
+          "failed to start stdio request worker", ex.what()));
     }
   }
 
+  wait_for_workers();
   running_.store(false, std::memory_order_release);
+  if (worker_error.has_value()) {
+    return mcp::core::unexpected(*worker_error);
+  }
   if (input_->bad()) {
     return mcp::core::unexpected(make_transport_error(
         static_cast<int>(protocol::ErrorCode::InternalError),

--- a/tests/client_server/test_client_server.cpp
+++ b/tests/client_server/test_client_server.cpp
@@ -1218,6 +1218,49 @@ void test_server_direct_facade_accepts_context_and_cancellation() {
           "peer context call_tool should pass context and cancellation");
 }
 
+void test_server_tool_context_exposes_call_meta_progress_token() {
+  mcp::server::ServerOptions options;
+  options.capabilities.tools.enabled = true;
+  mcp::server::Server server(options);
+
+  std::atomic_bool handler_called{false};
+  const auto tool_added = server.tools().add(
+      mcp::protocol::ToolDefinition{
+          .name = "progress-aware",
+          .input_schema = Json::object(),
+      },
+      [&](const mcp::server::ToolContext& context)
+          -> mcp::core::Result<mcp::protocol::ToolResult> {
+        handler_called.store(true, std::memory_order_relaxed);
+        require(context.meta.has_value(), "tool context meta missing");
+        require(context.meta->at("progressToken") == "progress-1",
+                "tool context meta progress token mismatch");
+        const auto progress_token = context.progress_token();
+        require(progress_token.has_value(),
+                "tool context progress token missing");
+        require(*progress_token ==
+                    mcp::protocol::ProgressToken{std::string("progress-1")},
+                "tool context progress token mismatch");
+        return mcp::protocol::ToolResult::text("ok");
+      });
+  require(tool_added.has_value(), "failed to add progress-aware tool");
+
+  const auto response = server.handle_request(
+      mcp::protocol::JsonRpcRequest{
+          .method = mcp::protocol::ToolsCallMethod,
+          .params = Json{{"name", "progress-aware"},
+                         {"arguments", Json::object()},
+                         {"_meta", Json{{"progressToken", "progress-1"},
+                                        {"traceId", "trace-1"}}}},
+          .id = std::int64_t{1},
+      },
+      mcp::server::SessionContext{.session_id = "session-1"});
+  require(response.has_value(), "progress-aware tool call failed");
+  require(response->result.has_value(), "progress-aware tool result missing");
+  require(handler_called.load(std::memory_order_relaxed),
+          "progress-aware tool handler not called");
+}
+
 void test_server_auth_provider_receives_headers_and_sets_identity() {
   class HeaderAuthProvider final : public mcp::server::AuthProvider {
    public:
@@ -4000,6 +4043,13 @@ void test_server_task_processor_tool_call_lifecycle() {
                 "task tool session mismatch");
         require(context.task.has_value(), "task tool context missing task");
         require(context.task->ttl == 60, "task tool ttl mismatch");
+        require(context.meta.has_value(), "task tool context meta missing");
+        const auto progress_token = context.progress_token();
+        require(progress_token.has_value(),
+                "task tool context progress token missing");
+        require(*progress_token ==
+                    mcp::protocol::ProgressToken{std::string("task-progress")},
+                "task tool context progress token mismatch");
         mcp::protocol::ToolResult result;
         result.structured_content =
             Json{{"echo", context.arguments.at("value")}};
@@ -4020,6 +4070,7 @@ void test_server_task_processor_tool_call_lifecycle() {
       .name = "long.echo",
       .arguments = Json{{"value", "hello"}},
       .task = mcp::protocol::TaskRequestParameters{.ttl = std::int64_t{60}},
+      .meta = Json{{"progressToken", "task-progress"}},
   });
   require(created.has_value(), "task-aware tool call should create task");
   require(!created->task.task_id.empty(), "created task id missing");
@@ -6991,6 +7042,8 @@ int main() {
        test_server_service_native_transport_stop_cancels_loop},
       {"client service native transport receive loop",
        test_client_service_native_transport_receive_loop},
+      {"server tool context exposes call meta progress token",
+       test_server_tool_context_exposes_call_meta_progress_token},
       {"server non-task tool observes cancelled notification",
        test_server_non_task_tool_observes_cancelled_notification},
       {"completion and sampling handlers observe cancellation token",

--- a/tests/transport/test_http_transport.cpp
+++ b/tests/transport/test_http_transport.cpp
@@ -3141,6 +3141,156 @@ void test_server_http_transport_accepts_standard_post_without_custom_headers() {
   server_transport.transport().stop();
 }
 
+void test_server_http_transport_runs_tools_calls_concurrently() {
+  constexpr int kPort = 40238;
+  const std::string kPath = "/mcp";
+
+  std::mutex gate_mutex;
+  std::condition_variable gate_cv;
+  bool slow_started = false;
+  bool slow_finished = false;
+  bool fast_started = false;
+  bool fast_started_while_slow_active = false;
+
+  RunningServerTransportFixture server_transport(
+      std::make_unique<mcp::server::HttpTransport>(
+          mcp::server::HttpTransportOptions{
+              .listen_host = "127.0.0.1",
+              .listen_port = kPort,
+              .path = kPath,
+          }),
+      [&](const mcp::protocol::JsonRpcRequest& request,
+          const mcp::server::SessionContext&)
+          -> mcp::core::Result<mcp::protocol::JsonRpcResponse> {
+        if (request.method == mcp::protocol::InitializeMethod) {
+          return mcp::protocol::JsonRpcResponse{
+              .id = request.id,
+              .result =
+                  Json{
+                      {"protocolVersion", mcp::protocol::McpProtocolVersion},
+                      {"capabilities", Json::object()},
+                      {"serverInfo",
+                       Json{{"name", "server-http-test"}, {"version", "1"}}},
+                  },
+          };
+        }
+        require(request.method == mcp::protocol::ToolsCallMethod,
+                "server should receive tools/call");
+        require(request.params.is_object() && request.params.contains("name"),
+                "tools/call should include a name");
+        const auto name = request.params.at("name").get<std::string>();
+        if (name == "slow") {
+          std::unique_lock lock(gate_mutex);
+          slow_started = true;
+          gate_cv.notify_all();
+          gate_cv.wait_for(lock, std::chrono::milliseconds(1500),
+                           [&] { return fast_started; });
+          slow_finished = true;
+          gate_cv.notify_all();
+        } else if (name == "fast") {
+          std::lock_guard lock(gate_mutex);
+          fast_started_while_slow_active = slow_started && !slow_finished;
+          fast_started = true;
+          gate_cv.notify_all();
+        } else {
+          return mcp::protocol::make_error_response(
+              std::optional<mcp::protocol::RequestId>{request.id},
+              mcp::protocol::make_error(
+                  mcp::protocol::ErrorCode::MethodNotFound, "unexpected tool"));
+        }
+        return mcp::protocol::JsonRpcResponse{
+            .id = request.id,
+            .result =
+                Json{
+                    {"content",
+                     Json::array({Json{{"type", "text"}, {"text", name}}})},
+                    {"isError", false},
+                },
+        };
+      });
+
+  require(!server_transport.start_error().has_value(),
+          "server transport should start");
+  require(wait_for_http_initialize(kPort, kPath),
+          "server transport should become reachable");
+  const auto session_id = initialize_http_session(kPort, kPath, 74);
+  require_initialized_notification(kPort, kPath, session_id);
+
+  auto post_tool_call = [&](std::string name, std::int64_t id) {
+    httplib::Client http_client("127.0.0.1", kPort);
+    http_client.set_read_timeout(std::chrono::milliseconds(3000));
+    return http_client.Post(
+        kPath,
+        httplib::Headers{
+            {"Accept", "application/json, text/event-stream"},
+            {"Content-Type", "application/json"},
+            {"MCP-Protocol-Version", mcp::protocol::McpProtocolVersion},
+            {"Mcp-Session-Id", session_id},
+            {"Mcp-Method", mcp::protocol::ToolsCallMethod},
+            {"Mcp-Name", name},
+        },
+        serialize_test_request(mcp::protocol::JsonRpcRequest{
+            .method = mcp::protocol::ToolsCallMethod,
+            .params = Json{{"name", name}, {"arguments", Json::object()}},
+            .id = id,
+        }),
+        "application/json");
+  };
+
+  std::optional<httplib::Result> slow_response;
+  std::exception_ptr slow_failure;
+  std::thread slow_thread([&]() {
+    try {
+      slow_response = post_tool_call("slow", 75);
+    } catch (...) {
+      slow_failure = std::current_exception();
+    }
+  });
+
+  bool observed_slow = false;
+  {
+    std::unique_lock lock(gate_mutex);
+    observed_slow = gate_cv.wait_for(lock, std::chrono::milliseconds(1000),
+                                     [&] { return slow_started; });
+  }
+
+  std::optional<httplib::Result> fast_response;
+  std::exception_ptr fast_failure;
+  try {
+    fast_response = post_tool_call("fast", 76);
+  } catch (...) {
+    fast_failure = std::current_exception();
+  }
+
+  if (slow_thread.joinable()) {
+    slow_thread.join();
+  }
+  if (fast_failure) {
+    std::rethrow_exception(fast_failure);
+  }
+  if (slow_failure) {
+    std::rethrow_exception(slow_failure);
+  }
+  require(observed_slow, "slow tools/call should reach handler");
+  require(fast_response.has_value() && static_cast<bool>(*fast_response),
+          "fast tools/call should return while slow call is active");
+  require((*fast_response)->status == 200,
+          "fast tools/call response status mismatch");
+  const auto parsed_fast =
+      mcp::protocol::parse_response((*fast_response)->body);
+  require(parsed_fast.has_value(), "fast tools/call response should parse");
+  require(parsed_fast->result.has_value(),
+          "fast tools/call should contain a result");
+  require(fast_started_while_slow_active,
+          "HTTP tools/call should run while slow call is active");
+  require(slow_response.has_value() && static_cast<bool>(*slow_response),
+          "slow tools/call should return");
+  require((*slow_response)->status == 200,
+          "slow tools/call response status mismatch");
+
+  server_transport.transport().stop();
+}
+
 void test_server_http_transport_rejects_invalid_required_headers() {
   constexpr int kPort = 40236;
   const std::string kPath = "/mcp";
@@ -5970,6 +6120,8 @@ int main() {
        test_server_http_transport_rejects_disallowed_host},
       {"server http transport accepts standard post without custom headers",
        test_server_http_transport_accepts_standard_post_without_custom_headers},
+      {"server http transport runs tools/call concurrently",
+       test_server_http_transport_runs_tools_calls_concurrently},
       {"server http transport rejects invalid required headers",
        test_server_http_transport_rejects_invalid_required_headers},
       {"server http transport can request client",

--- a/tests/transport/test_stdio_transport.cpp
+++ b/tests/transport/test_stdio_transport.cpp
@@ -1,7 +1,10 @@
 // Copyright (c) 2025 [caomengxuan666]
 
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <iostream>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -444,6 +447,88 @@ void test_server_writes_error_for_throwing_stdio_request_handler() {
           "server handler error detail mismatch");
 }
 
+void test_server_runs_post_initialize_stdio_requests_concurrently() {
+  const auto input_text = initialized_stdio_prefix() +
+                          serialize_request_line(mcp::protocol::JsonRpcRequest{
+                              .method = "slow",
+                              .params = Json::object(),
+                              .id = std::int64_t{1},
+                          }) +
+                          serialize_request_line(mcp::protocol::JsonRpcRequest{
+                              .method = "fast",
+                              .params = Json::object(),
+                              .id = std::int64_t{2},
+                          });
+  std::istringstream input(input_text);
+  std::ostringstream output;
+  mcp::server::StdioTransport transport(input, output);
+
+  std::mutex gate_mutex;
+  std::condition_variable gate_cv;
+  bool slow_started = false;
+  bool slow_finished = false;
+  bool fast_started = false;
+  bool fast_started_while_slow_active = false;
+
+  const auto started =
+      transport.start([&](const mcp::protocol::JsonRpcRequest& request,
+                          const mcp::server::SessionContext&)
+                          -> mcp::core::Result<mcp::protocol::JsonRpcResponse> {
+        if (request.method == mcp::protocol::InitializeMethod) {
+          return make_initialize_response(request.id);
+        }
+        if (request.method == "slow") {
+          std::unique_lock lock(gate_mutex);
+          slow_started = true;
+          gate_cv.notify_all();
+          gate_cv.wait_for(lock, std::chrono::milliseconds(1000),
+                           [&] { return fast_started; });
+          slow_finished = true;
+          gate_cv.notify_all();
+          return mcp::protocol::make_response(request.id,
+                                              Json{{"name", "slow"}});
+        }
+        if (request.method == "fast") {
+          std::lock_guard lock(gate_mutex);
+          fast_started_while_slow_active = slow_started && !slow_finished;
+          fast_started = true;
+          gate_cv.notify_all();
+          return mcp::protocol::make_response(request.id,
+                                              Json{{"name", "fast"}});
+        }
+        return mcp::protocol::make_error_response(
+            std::optional<mcp::protocol::RequestId>{request.id},
+            mcp::protocol::make_error(mcp::protocol::ErrorCode::MethodNotFound,
+                                      "unexpected request"));
+      });
+
+  require(started.has_value(),
+          "server concurrent stdio start should complete at EOF");
+  require(fast_started_while_slow_active,
+          "stdio request handler should run while slow request is active");
+
+  const auto lines = non_empty_lines(output.str());
+  require(lines.size() == 3,
+          "server should write initialize, slow, and fast responses");
+  bool saw_slow = false;
+  bool saw_fast = false;
+  for (const auto& line : lines) {
+    const auto parsed = mcp::protocol::parse_response(line);
+    require(parsed.has_value(), "concurrent stdio response should parse");
+    if (!parsed->result.has_value() || !parsed->result->contains("name")) {
+      continue;
+    }
+    if (parsed->result->at("name") == "slow") {
+      saw_slow = true;
+    }
+    if (parsed->result->at("name") == "fast") {
+      saw_fast = true;
+    }
+  }
+  require(saw_slow, "server should write slow response");
+  require(saw_fast, "server should write fast response");
+}
+
 void test_server_writes_parse_error_for_bad_json() {
   std::istringstream input("{not json\n");
   std::ostringstream output;
@@ -631,6 +716,8 @@ int main() {
        test_server_writes_error_for_unexpected_stdio_response},
       {"server writes error for throwing stdio request handler",
        test_server_writes_error_for_throwing_stdio_request_handler},
+      {"server runs post-initialize stdio requests concurrently",
+       test_server_runs_post_initialize_stdio_requests_concurrently},
       {"server writes parse error for bad json",
        test_server_writes_parse_error_for_bad_json},
       {"server handles notifications", test_server_handles_notifications},


### PR DESCRIPTION
## 概要

- 将 `ToolCall._meta` 传入 `ToolContext`，并提供 `ToolContext::progress_token()` 便捷访问 `tools/call` 的 `_meta.progressToken`
- 让 legacy stdio server 在初始化完成后并发执行请求 handler，避免慢工具阻塞后续请求
- 增加 stdio / HTTP / client-server 回归测试，覆盖 progressToken 传递和并发 tools/call 行为

## 验证

- `pwsh -NoProfile -File scripts\format.ps1 -Check`
- `git diff --check`
- `python -B scripts/check_release_evidence.py --source .`
- `ctest --test-dir build-issue43 -R "^(stdio_transport|http_transport|client_server)$" --output-on-failure --timeout 600`
- `ctest --test-dir build-issue43 -R "^package_smoke$" --output-on-failure --timeout 900` inside VS Developer Command Prompt

Fixes #55
Fixes #51