### PR TITLE
[codex] docs: document CMake configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,15 +119,21 @@ Package managers: `conanfile.py` (Conan 2), `packaging/vcpkg/ports/cxxmcp-sdk` (
 | Option | Default | Description |
 |---|---:|---|
 | `CXXMCP_BUILD_SDK` | `ON` | Build the aggregate SDK layer (protocol + client + server) |
+| `CXXMCP_BUILD_PROTOCOL` | `ON` | Build the MCP protocol library |
 | `CXXMCP_BUILD_CLIENT` | `OFF` | Build the MCP client library |
 | `CXXMCP_BUILD_SERVER` | `OFF` | Build the MCP server library |
 | `CXXMCP_BUILD_EXAMPLES` | `OFF` | Build example executables |
 | `CXXMCP_BUILD_TESTS` | `BUILD_TESTING` | Build tests |
 | `CXXMCP_BUILD_BENCHMARKS` | `OFF` | Build benchmark executables |
+| `CXXMCP_BUILD_DOCS` | `OFF` | Build Doxygen API documentation |
 | `CXXMCP_ENABLE_HTTP` | `OFF` | Build HTTP/SSE transport (uses bundled `cpp-httplib` unless `CXXMCP_USE_SYSTEM_DEPS=ON`) |
 | `CXXMCP_ENABLE_OPENSSL` | `OFF` | Enable OpenSSL-backed HTTP/WebSocket TLS support |
 | `CXXMCP_ENABLE_AUTH` | `OFF` | Build the optional OAuth 2.1 / DPoP auth target |
+| `CXXMCP_AUTH_CRYPTO` | `NONE` | Optional auth crypto backend (`NONE` or `OpenSSL`; requires `CXXMCP_ENABLE_AUTH=ON`) |
 | `CXXMCP_ENABLE_WEBSOCKET` | `OFF` | Build WebSocket transport (requires `CXXMCP_ENABLE_HTTP`) |
+| `CXXMCP_USE_SYSTEM_DEPS` | `OFF` | Use package-manager dependencies instead of bundled header-only SDK dependencies |
+| `CXXMCP_SDK_CXX_STANDARD` | `17` | Minimum C++ standard required by exported SDK targets (`17`, `20`, `23`, or `26`) |
+| `CXXMCP_MSVC_RUNTIME_LIBRARY` | empty | Optional MSVC runtime library override; empty keeps the toolchain default |
 
 ## Package Targets
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -119,15 +119,21 @@ client 路径，还需要加上 `-DCXXMCP_ENABLE_HTTP=ON`。
 | Option | Default | 说明 |
 |---|---:|---|
 | `CXXMCP_BUILD_SDK` | `ON` | 构建聚合 SDK 层（protocol + client + server） |
+| `CXXMCP_BUILD_PROTOCOL` | `ON` | 构建 MCP protocol library |
 | `CXXMCP_BUILD_CLIENT` | `OFF` | 构建 MCP client library |
 | `CXXMCP_BUILD_SERVER` | `OFF` | 构建 MCP server library |
 | `CXXMCP_BUILD_EXAMPLES` | `OFF` | 构建示例 |
 | `CXXMCP_BUILD_TESTS` | `BUILD_TESTING` | 构建测试 |
 | `CXXMCP_BUILD_BENCHMARKS` | `OFF` | 构建 benchmark 可执行文件 |
+| `CXXMCP_BUILD_DOCS` | `OFF` | 构建 Doxygen API 文档 |
 | `CXXMCP_ENABLE_HTTP` | `OFF` | 构建 HTTP/SSE transport（默认使用 bundled `cpp-httplib`，`CXXMCP_USE_SYSTEM_DEPS=ON` 时使用系统包） |
 | `CXXMCP_ENABLE_OPENSSL` | `OFF` | 启用 OpenSSL-backed HTTP/WebSocket TLS 支持 |
-| `CXXMCP_ENABLE_WEBSOCKET` | `OFF` | 构建 WebSocket transport（需要 `CXXMCP_ENABLE_HTTP`） |
 | `CXXMCP_ENABLE_AUTH` | `OFF` | 构建可选 OAuth 2.1 / DPoP auth target |
+| `CXXMCP_AUTH_CRYPTO` | `NONE` | 可选 auth crypto backend（`NONE` 或 `OpenSSL`；需要 `CXXMCP_ENABLE_AUTH=ON`） |
+| `CXXMCP_ENABLE_WEBSOCKET` | `OFF` | 构建 WebSocket transport（需要 `CXXMCP_ENABLE_HTTP`） |
+| `CXXMCP_USE_SYSTEM_DEPS` | `OFF` | 使用包管理器依赖，而不是 bundled header-only SDK 依赖 |
+| `CXXMCP_SDK_CXX_STANDARD` | `17` | exported SDK targets 要求的最低 C++ 标准（`17`、`20`、`23` 或 `26`） |
+| `CXXMCP_MSVC_RUNTIME_LIBRARY` | empty | 可选 MSVC runtime library 覆盖；留空表示沿用 toolchain 默认值 |
 
 ## Package Targets
 


### PR DESCRIPTION
## Summary

- document CMake options that exist in `CMakeLists.txt` but were missing from the README option tables
- keep the English and Chinese README CMake option references aligned

## Validation

- `python -B scripts\check_source_markers.py --source .`
- `python -B scripts\check_package_recipe_sync.py --source .`
- `pwsh -NoProfile -File scripts\format.ps1 -Check -ClangFormat C:\Users\27910\AppData\Roaming\Python\Python313\Scripts\clang-format.exe`

## Notes

This is a docs-only change and does not alter public SDK headers, package recipes, or generated Pages content.