### PR TITLE
[codex] fix: reap completed HTTP request workers

### DIFF
--- a/sdk/client/src/http_transport.cpp
+++ b/sdk/client/src/http_transport.cpp
@@ -2,6 +2,7 @@
 
 #include "cxxmcp/client/http_transport.hpp"
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <ctime>
@@ -10,6 +11,7 @@
 #include <functional>
 #include <future>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <set>
@@ -1102,6 +1104,11 @@ std::string request_id_to_string_for_native_http(
 
 class StreamableHttpClientTransport::Impl {
  public:
+  struct RequestWorker {
+    std::thread thread;
+    std::shared_ptr<std::atomic_bool> done;
+  };
+
   explicit Impl(StreamableHttpClientTransportOptions options)
       : transport_(to_legacy_options(std::move(options))) {}
 
@@ -1165,7 +1172,7 @@ class StreamableHttpClientTransport::Impl {
   core::Result<core::Unit> close() {
     std::map<protocol::RequestId, std::shared_ptr<PendingServerRequest>>
         pending;
-    std::vector<std::thread> request_threads;
+    std::vector<RequestWorker> request_threads;
     {
       std::lock_guard<std::mutex> lock(mutex_);
       if (closed_) {
@@ -1189,9 +1196,10 @@ class StreamableHttpClientTransport::Impl {
 
     receive_cv_.notify_all();
     transport_.stop();
-    for (auto& thread : request_threads) {
-      if (thread.joinable() && thread.get_id() != std::this_thread::get_id()) {
-        thread.join();
+    for (auto& worker : request_threads) {
+      if (worker.thread.joinable() &&
+          worker.thread.get_id() != std::this_thread::get_id()) {
+        worker.thread.join();
       }
     }
     return core::Unit{};
@@ -1207,6 +1215,33 @@ class StreamableHttpClientTransport::Impl {
     std::condition_variable cv;
     std::optional<protocol::JsonRpcResponse> response;
   };
+
+  static void join_request_threads(std::vector<std::thread>& threads) {
+    for (auto& thread : threads) {
+      if (thread.joinable() && thread.get_id() != std::this_thread::get_id()) {
+        thread.join();
+      }
+    }
+  }
+
+  std::vector<std::thread> reap_completed_request_workers_locked() {
+    std::vector<std::thread> completed_threads;
+    auto output = request_threads_.begin();
+    for (auto input = request_threads_.begin(); input != request_threads_.end();
+         ++input) {
+      if (input->done != nullptr &&
+          input->done->load(std::memory_order_acquire)) {
+        completed_threads.push_back(std::move(input->thread));
+        continue;
+      }
+      if (output != input) {
+        *output = std::move(*input);
+      }
+      ++output;
+    }
+    request_threads_.erase(output, request_threads_.end());
+    return completed_threads;
+  }
 
   core::Result<core::Unit> ensure_started() {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -1238,6 +1273,7 @@ class StreamableHttpClientTransport::Impl {
       protocol::JsonRpcRequest request) {
     const auto request_id = request.id;
     bool registered = false;
+    std::vector<std::thread> completed_threads;
     try {
       std::lock_guard<std::mutex> lock(mutex_);
       if (closed_) {
@@ -1245,6 +1281,7 @@ class StreamableHttpClientTransport::Impl {
             protocol::ErrorCode::InvalidRequest,
             "streamable http client transport is closed"));
       }
+      completed_threads = reap_completed_request_workers_locked();
       const auto [_, inserted] = in_flight_request_ids_.insert(request_id);
       if (!inserted) {
         return mcp::core::unexpected(make_native_http_error(
@@ -1254,33 +1291,40 @@ class StreamableHttpClientTransport::Impl {
       }
       registered = true;
       ++active_request_workers_;
-      request_threads_.emplace_back(
-          [this, request_id, request = std::move(request)]() mutable {
-            auto response = transport_.send(request);
-            if (response) {
-              finish_request_worker(request_id, false, false);
-              enqueue(protocol::JsonRpcMessage{std::move(*response)});
-              return;
-            }
-            finish_request_worker(request_id, true,
-                                  is_timeout_error(response.error()));
-            enqueue(protocol::JsonRpcMessage{protocol::make_error_response(
-                std::optional<protocol::RequestId>{request.id},
-                protocol::make_error(response.error().code,
-                                     response.error().message,
-                                     response.error().detail.empty()
-                                         ? std::nullopt
-                                         : std::optional<protocol::Json>{
-                                               response.error().detail}))});
-          });
+      auto done = std::make_shared<std::atomic_bool>(false);
+      request_threads_.push_back(RequestWorker{
+          std::thread(
+              [this, request_id, request = std::move(request), done]() mutable {
+                auto response = transport_.send(request);
+                if (response) {
+                  finish_request_worker(request_id, false, false);
+                  enqueue(protocol::JsonRpcMessage{std::move(*response)});
+                  done->store(true, std::memory_order_release);
+                  return;
+                }
+                finish_request_worker(request_id, true,
+                                      is_timeout_error(response.error()));
+                enqueue(protocol::JsonRpcMessage{protocol::make_error_response(
+                    std::optional<protocol::RequestId>{request.id},
+                    protocol::make_error(response.error().code,
+                                         response.error().message,
+                                         response.error().detail.empty()
+                                             ? std::nullopt
+                                             : std::optional<protocol::Json>{
+                                                   response.error().detail}))});
+                done->store(true, std::memory_order_release);
+              }),
+          done});
     } catch (const std::system_error& ex) {
       if (registered) {
         forget_request_worker(request_id);
       }
+      join_request_threads(completed_threads);
       return mcp::core::unexpected(make_native_http_error(
           protocol::ErrorCode::InternalError,
           "failed to start streamable http request worker", ex.what()));
     }
+    join_request_threads(completed_threads);
     return core::Unit{};
   }
 
@@ -1398,7 +1442,7 @@ class StreamableHttpClientTransport::Impl {
   std::map<protocol::RequestId, std::shared_ptr<PendingServerRequest>>
       pending_server_requests_;
   std::set<protocol::RequestId> in_flight_request_ids_;
-  std::vector<std::thread> request_threads_;
+  std::vector<RequestWorker> request_threads_;
   std::size_t active_request_workers_ = 0;
   std::size_t completed_request_workers_ = 0;
   std::size_t failed_request_workers_ = 0;

--- a/sdk/server/src/http_transport.cpp
+++ b/sdk/server/src/http_transport.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cctype>
 #include <chrono>
 #include <condition_variable>
@@ -12,6 +13,7 @@
 #include <exception>
 #include <future>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
@@ -2389,6 +2391,11 @@ StreamableHttpServerMessageContext to_native_server_message_context(
 
 class StreamableHttpServerTransport::Impl {
  public:
+  struct RequestWorker {
+    std::thread thread;
+    std::shared_ptr<std::atomic_bool> done;
+  };
+
   explicit Impl(StreamableHttpServerTransportOptions options)
       : transport_(to_legacy_options(std::move(options))) {}
 
@@ -2473,7 +2480,7 @@ class StreamableHttpServerTransport::Impl {
 
   core::Result<core::Unit> close() {
     std::map<std::string, std::shared_ptr<PendingClientRequest>> pending;
-    std::vector<std::thread> request_threads;
+    std::vector<RequestWorker> request_threads;
     {
       std::lock_guard<std::mutex> lock(mutex_);
       if (closed_) {
@@ -2497,9 +2504,10 @@ class StreamableHttpServerTransport::Impl {
 
     receive_cv_.notify_all();
     transport_.stop();
-    for (auto& thread : request_threads) {
-      if (thread.joinable() && thread.get_id() != std::this_thread::get_id()) {
-        thread.join();
+    for (auto& worker : request_threads) {
+      if (worker.thread.joinable() &&
+          worker.thread.get_id() != std::this_thread::get_id()) {
+        worker.thread.join();
       }
     }
     if (server_thread_.joinable() &&
@@ -2524,6 +2532,33 @@ class StreamableHttpServerTransport::Impl {
     protocol::JsonRpcMessage message;
     std::optional<StreamableHttpServerMessageContext> context;
   };
+
+  static void join_request_threads(std::vector<std::thread>& threads) {
+    for (auto& thread : threads) {
+      if (thread.joinable() && thread.get_id() != std::this_thread::get_id()) {
+        thread.join();
+      }
+    }
+  }
+
+  std::vector<std::thread> reap_completed_request_workers_locked() {
+    std::vector<std::thread> completed_threads;
+    auto output = request_threads_.begin();
+    for (auto input = request_threads_.begin(); input != request_threads_.end();
+         ++input) {
+      if (input->done != nullptr &&
+          input->done->load(std::memory_order_acquire)) {
+        completed_threads.push_back(std::move(input->thread));
+        continue;
+      }
+      if (output != input) {
+        *output = std::move(*input);
+      }
+      ++output;
+    }
+    request_threads_.erase(output, request_threads_.end());
+    return completed_threads;
+  }
 
   core::Result<core::Unit> ensure_started() {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -2570,6 +2605,7 @@ class StreamableHttpServerTransport::Impl {
 
   core::Result<core::Unit> start_request_thread(
       protocol::JsonRpcRequest request) {
+    std::vector<std::thread> completed_threads;
     try {
       std::lock_guard<std::mutex> lock(mutex_);
       if (closed_) {
@@ -2577,13 +2613,16 @@ class StreamableHttpServerTransport::Impl {
             protocol::ErrorCode::InvalidRequest,
             "streamable http server transport is closed"));
       }
+      completed_threads = reap_completed_request_workers_locked();
       ++active_request_workers_;
-      request_threads_.emplace_back(
-          [this, request = std::move(request)]() mutable {
+      auto done = std::make_shared<std::atomic_bool>(false);
+      request_threads_.push_back(RequestWorker{
+          std::thread([this, request = std::move(request), done]() mutable {
             auto response = transport_.send_request(request);
             if (response) {
               finish_request_worker(false, false);
               enqueue(protocol::JsonRpcMessage{std::move(*response)});
+              done->store(true, std::memory_order_release);
               return;
             }
             finish_request_worker(true, is_timeout_error(response.error()));
@@ -2595,13 +2634,17 @@ class StreamableHttpServerTransport::Impl {
                                          ? std::nullopt
                                          : std::optional<protocol::Json>{
                                                response.error().detail}))});
-          });
+            done->store(true, std::memory_order_release);
+          }),
+          done});
     } catch (const std::system_error& ex) {
       finish_request_worker(true, false);
+      join_request_threads(completed_threads);
       return mcp::core::unexpected(make_native_server_http_error(
           protocol::ErrorCode::InternalError,
           "failed to start streamable http server request worker", ex.what()));
     }
+    join_request_threads(completed_threads);
     return core::Unit{};
   }
 
@@ -2741,7 +2784,7 @@ class StreamableHttpServerTransport::Impl {
   std::optional<StreamableHttpServerMessageContext> last_context_;
   std::map<std::string, std::shared_ptr<PendingClientRequest>>
       pending_client_requests_;
-  std::vector<std::thread> request_threads_;
+  std::vector<RequestWorker> request_threads_;
   std::size_t active_request_workers_ = 0;
   std::size_t completed_request_workers_ = 0;
   std::size_t failed_request_workers_ = 0;

--- a/tests/transport/test_http_transport.cpp
+++ b/tests/transport/test_http_transport.cpp
@@ -4796,6 +4796,8 @@ void test_native_streamable_http_transport_exposes_client_contract() {
   require(tools_response->result->at("tools").size() == 1,
           "native http tools/list count mismatch");
   const auto diagnostics = transport.diagnostics();
+  require(diagnostics.at("requestWorkers").get<std::size_t>() <= 1,
+          "native http completed request workers should be reaped");
   require(diagnostics.at("activeRequestWorkers").get<std::size_t>() == 0,
           "native http request workers should be inactive");
   require(diagnostics.at("completedRequestWorkers").get<std::size_t>() >= 2,
@@ -5317,7 +5319,29 @@ void test_native_streamable_http_server_transport_diagnostics_timeout_cleanup() 
       timeout_response->error->message.find("timed out") != std::string::npos,
       "native timeout server error should be a timeout");
 
+  const auto second_request_sent = transport.send(mcp::protocol::JsonRpcRequest{
+      .method = mcp::protocol::RootsListMethod,
+      .params = Json::object(),
+      .id = std::int64_t{73},
+  });
+  require(second_request_sent.has_value(),
+          "native timeout server second request should be accepted");
+
+  received = transport.receive();
+  require(received.has_value(),
+          "native timeout server second error receive should succeed");
+  require(received->has_value(),
+          "native timeout server second error response should be queued");
+  const auto* second_timeout_response =
+      std::get_if<mcp::protocol::JsonRpcResponse>(&received->value());
+  require(second_timeout_response != nullptr,
+          "native timeout server should receive second error response");
+  require(second_timeout_response->error.has_value(),
+          "native timeout server second request should surface an error");
+
   const auto diagnostics = transport.diagnostics();
+  require(diagnostics.at("requestWorkers").get<std::size_t>() <= 1,
+          "native timeout server completed request workers should be reaped");
   require(diagnostics.at("pendingClientRequests").get<std::size_t>() == 0,
           "native timeout server should not leave pending client requests");
   require(diagnostics.at("activeRequestWorkers").get<std::size_t>() == 0,


### PR DESCRIPTION
## Summary- reap completed native Streamable HTTP request worker threads before starting new workers- apply the cleanup to both client and server native HTTP transport wrappers- add regression assertions so completed workers do not accumulate in diagnostics after sequential request churn## WhyThe native Streamable HTTP wrappers keep each outbound request in a `std::thread` and only joined those threads when the transport was closed. Under high request volume, completed joinable worker objects could remain in `request_threads_` for the lifetime of the transport, growing handle and memory usage even when `activeRequestWorkers` had returned to zero.This change keeps the existing close-time join path, but also reaps finished workers incrementally before new workers are spawned.## Validation- `pwsh -NoProfile -File scripts\format.ps1 -Check -ClangFormat C:\Users\27910\AppData\Roaming\Python\Python313\Scripts\clang-format.exe`- `python -B scripts\check_source_markers.py --source .`- `python -B scripts\check_sdk_header_boundaries.py --source .`- `cmake -S . -B out/build/llvm-http -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=C:\Users\27910\Documents\Codex\2026-07-22\c-users-27910-documents-xwechat-files\work\tools\llvm-mingw\bin\clang++.exe -DCMAKE_CXX_FLAGS=-D_WIN32_WINNT=0x0A00 -DCXXMCP_BUILD_SDK=ON -DCXXMCP_BUILD_CLIENT=ON -DCXXMCP_BUILD_SERVER=ON -DCXXMCP_BUILD_TESTS=ON -DCXXMCP_ENABLE_HTTP=ON -DCXXMCP_ENABLE_WEBSOCKET=OFF`- `cmake --build out/build/llvm-http --target mcp_http_transport_tests --parallel`- `ctest --test-dir out/build/llvm-http -R "^http_transport$" --output-on-failure --timeout 180`## Compatibility NotesNo public SDK headers or package targets changed. The diagnostics `requestWorkers` value now reflects live plus not-yet-reaped worker slots rather than all historical completed request threads retained since transport startup.

Closes #60
