### PR TITLE
Fix ServerPeer tool call concurrency

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,15 +62,14 @@ jobs:
             -DCXXMCP_BUILD_CLIENT=ON \
             -DCXXMCP_BUILD_SERVER=ON \
             -DCXXMCP_BUILD_EXAMPLES=OFF \
-            -DCXXMCP_BUILD_TESTS=ON \
+            -DCXXMCP_BUILD_TESTS=OFF \
             -DCXXMCP_BUILD_DOCS=OFF \
             -DCXXMCP_ENABLE_HTTP=ON \
             -DCXXMCP_ENABLE_WEBSOCKET=ON \
             -DCXXMCP_ENABLE_AUTH=ON
 
       - name: Build SDK for analysis
-        run: cmake --build out/build/codeql --parallel
+        run: cmake --build out/build/codeql --target mcp_protocol mcp_client mcp_server --parallel 2
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4
-

--- a/sdk/include/cxxmcp/peer.hpp
+++ b/sdk/include/cxxmcp/peer.hpp
@@ -3893,64 +3893,229 @@ class Peer<RoleServer> {
         "server peer cannot dispatch an uncorrelated response"));
   }
 
-  /// @brief Runs a sequential receive loop over a role-generic server
-  /// transport.
+  /// @brief Runs a receive loop over a role-generic server transport.
+  ///
+  /// Initialize handshakes and notifications are dispatched on the receive
+  /// thread. After initialization, requests are dispatched on workers so a
+  /// long-running tool call does not block the transport from reading later
+  /// requests.
   core::Result<core::Unit> serve_transport(
       transport::ServerTransport& transport,
       const server::SessionContext& context = {},
       CancellationToken cancellation = CancellationToken::none()) {
+    struct WorkerState {
+      std::mutex mutex;
+      std::mutex send_mutex;
+      std::condition_variable cv;
+      std::size_t active = 0;
+      std::optional<core::Error> first_error;
+    };
+
+    auto worker_state = std::make_shared<WorkerState>();
     bool initialized = false;
-    return detail::serve_transport_loop(
-        transport, cancellation,
-        [this, &context, &transport,
-         initialized](const protocol::JsonRpcMessage& message) mutable
-            -> core::Result<std::optional<protocol::JsonRpcMessage>> {
-          // Detect stateless mode: _meta contains protocolVersion
-          auto is_stateless_request = [](const protocol::Json& params) -> bool {
-            return params.is_object() && params.contains("_meta") &&
-                   params.at("_meta").is_object() &&
-                   params.at("_meta").contains(
-                       "io.modelcontextprotocol/protocolVersion");
-          };
-          if (const auto* request =
-                  std::get_if<protocol::JsonRpcRequest>(&message)) {
-            const bool stateless = is_stateless_request(request->params);
-            const bool allowed_before_initialized =
-                stateless || request->method == protocol::InitializeMethod ||
-                request->method == protocol::PingMethod;
-            if (!initialized && !allowed_before_initialized) {
-              return core::Result<std::optional<protocol::JsonRpcMessage>>{
-                  protocol::JsonRpcMessage{protocol::make_error_response(
-                      request->id,
-                      protocol::make_error(protocol::ErrorCode::InvalidRequest,
-                                           "server peer transport session is "
-                                           "not initialized"))}};
-            }
-          }
-          if (const auto* notification =
-                  std::get_if<protocol::JsonRpcNotification>(&message)) {
-            const bool stateless = is_stateless_request(notification->params);
-            if (!initialized && !stateless &&
-                notification->method != protocol::InitializedMethod) {
-              return mcp::core::unexpected(detail::peer_dispatch_error(
-                  "server peer transport session is not initialized"));
-            }
-            auto message_context =
-                detail::context_for_received_server_message(transport, context);
-            auto dispatched =
-                dispatch_message(message, message_context, &transport);
+
+    auto record_worker_error = [worker_state,
+                                &transport](core::Error error) noexcept {
+      {
+        std::lock_guard lock(worker_state->mutex);
+        if (!worker_state->first_error.has_value()) {
+          worker_state->first_error = std::move(error);
+        }
+      }
+      (void)transport.close();
+      worker_state->cv.notify_all();
+    };
+
+    auto finish_worker = [worker_state]() noexcept {
+      {
+        std::lock_guard lock(worker_state->mutex);
+        if (worker_state->active > 0) {
+          --worker_state->active;
+        }
+      }
+      worker_state->cv.notify_all();
+    };
+
+    auto wait_for_workers = [worker_state]() -> std::optional<core::Error> {
+      std::unique_lock lock(worker_state->mutex);
+      worker_state->cv.wait(lock, [&] { return worker_state->active == 0; });
+      return worker_state->first_error;
+    };
+
+    auto send_message =
+        [worker_state, &transport](
+            protocol::JsonRpcMessage message) -> core::Result<core::Unit> {
+      std::lock_guard lock(worker_state->send_mutex);
+      return transport.send(std::move(message));
+    };
+
+    auto dispatch_and_send = [this, &transport, &send_message](
+                                 const protocol::JsonRpcMessage& message,
+                                 const server::SessionContext& message_context)
+        -> core::Result<core::Unit> {
+      auto dispatched = dispatch_message(message, message_context, &transport);
+      if (!dispatched) {
+        return mcp::core::unexpected(dispatched.error());
+      }
+      if (dispatched->has_value()) {
+        auto sent = send_message(std::move(dispatched->value()));
+        if (!sent) {
+          return mcp::core::unexpected(sent.error());
+        }
+      }
+      return core::Unit{};
+    };
+
+    auto start_request_worker = [worker_state, &record_worker_error,
+                                 &finish_worker, &dispatch_and_send](
+                                    protocol::JsonRpcMessage message,
+                                    server::SessionContext message_context)
+        -> core::Result<core::Unit> {
+      {
+        std::lock_guard lock(worker_state->mutex);
+        ++worker_state->active;
+      }
+
+      try {
+        std::thread([message = std::move(message),
+                     message_context = std::move(message_context),
+                     &dispatch_and_send, record_worker_error,
+                     finish_worker]() mutable {
+          try {
+            auto dispatched = dispatch_and_send(message, message_context);
             if (!dispatched) {
-              return dispatched;
+              record_worker_error(dispatched.error());
             }
-            if (notification->method == protocol::InitializedMethod) {
-              initialized = true;
-            }
-            return dispatched;
+          } catch (const std::exception& ex) {
+            record_worker_error(errors::make(
+                protocol::ErrorCode::InternalError,
+                "server peer request worker failed", ex.what(), "transport"));
+          } catch (...) {
+            record_worker_error(
+                errors::make(protocol::ErrorCode::InternalError,
+                             "server peer request worker failed",
+                             "unknown exception", "transport"));
           }
-          auto message_context =
-              detail::context_for_received_server_message(transport, context);
-          return dispatch_message(message, message_context, &transport);
-        });
+          finish_worker();
+        }).detach();
+      } catch (const std::system_error& ex) {
+        finish_worker();
+        return mcp::core::unexpected(
+            errors::make(protocol::ErrorCode::InternalError,
+                         "failed to start server peer request worker",
+                         ex.what(), "transport"));
+      }
+      return core::Unit{};
+    };
+
+    auto is_stateless_request = [](const protocol::Json& params) -> bool {
+      return params.is_object() && params.contains("_meta") &&
+             params.at("_meta").is_object() &&
+             params.at("_meta").contains(
+                 "io.modelcontextprotocol/protocolVersion");
+    };
+
+    while (!cancellation.cancelled()) {
+      auto received = transport.receive();
+      if (!received) {
+        if (const auto worker_error = wait_for_workers()) {
+          return mcp::core::unexpected(*worker_error);
+        }
+        return mcp::core::unexpected(received.error());
+      }
+      if (!received->has_value()) {
+        if (const auto worker_error = wait_for_workers()) {
+          return mcp::core::unexpected(*worker_error);
+        }
+        return core::Unit{};
+      }
+
+      auto message = std::move(received->value());
+      if (const auto* request =
+              std::get_if<protocol::JsonRpcRequest>(&message)) {
+        const bool stateless = is_stateless_request(request->params);
+        const bool allowed_before_initialized =
+            stateless || request->method == protocol::InitializeMethod ||
+            request->method == protocol::PingMethod;
+        if (!initialized && !allowed_before_initialized) {
+          auto sent = send_message(
+              protocol::JsonRpcMessage{protocol::make_error_response(
+                  request->id,
+                  protocol::make_error(protocol::ErrorCode::InvalidRequest,
+                                       "server peer transport session is "
+                                       "not initialized"))});
+          if (!sent) {
+            if (const auto worker_error = wait_for_workers()) {
+              return mcp::core::unexpected(*worker_error);
+            }
+            return mcp::core::unexpected(sent.error());
+          }
+          continue;
+        }
+
+        auto message_context =
+            detail::context_for_received_server_message(transport, context);
+        const bool run_inline = request->method == protocol::InitializeMethod ||
+                                (!initialized && !stateless);
+        if (run_inline) {
+          auto dispatched = dispatch_and_send(message, message_context);
+          if (!dispatched) {
+            if (const auto worker_error = wait_for_workers()) {
+              return mcp::core::unexpected(*worker_error);
+            }
+            return mcp::core::unexpected(dispatched.error());
+          }
+          continue;
+        }
+
+        auto started = start_request_worker(std::move(message),
+                                            std::move(message_context));
+        if (!started) {
+          if (const auto worker_error = wait_for_workers()) {
+            return mcp::core::unexpected(*worker_error);
+          }
+          return mcp::core::unexpected(started.error());
+        }
+        continue;
+      }
+
+      if (const auto* notification =
+              std::get_if<protocol::JsonRpcNotification>(&message)) {
+        const bool stateless = is_stateless_request(notification->params);
+        if (!initialized && !stateless &&
+            notification->method != protocol::InitializedMethod) {
+          if (const auto worker_error = wait_for_workers()) {
+            return mcp::core::unexpected(*worker_error);
+          }
+          return mcp::core::unexpected(detail::peer_dispatch_error(
+              "server peer transport session is not initialized"));
+        }
+        auto message_context =
+            detail::context_for_received_server_message(transport, context);
+        auto dispatched = dispatch_and_send(message, message_context);
+        if (!dispatched) {
+          if (const auto worker_error = wait_for_workers()) {
+            return mcp::core::unexpected(*worker_error);
+          }
+          return mcp::core::unexpected(dispatched.error());
+        }
+        if (notification->method == protocol::InitializedMethod) {
+          initialized = true;
+        }
+        continue;
+      }
+
+      if (const auto worker_error = wait_for_workers()) {
+        return mcp::core::unexpected(*worker_error);
+      }
+      return mcp::core::unexpected(detail::peer_dispatch_error(
+          "server peer cannot dispatch an uncorrelated response"));
+    }
+
+    if (const auto worker_error = wait_for_workers()) {
+      return mcp::core::unexpected(*worker_error);
+    }
+    return core::Unit{};
   }
 
  private:

--- a/tests/client_server/test_client_server.cpp
+++ b/tests/client_server/test_client_server.cpp
@@ -601,6 +601,9 @@ class QueuedRoleServerTransport final : public mcp::transport::ServerTransport {
     if (next_inbound_ >= inbound.size()) {
       return std::nullopt;
     }
+    if (before_receive) {
+      before_receive(next_inbound_);
+    }
     auto message = std::move(inbound.at(next_inbound_));
     ++next_inbound_;
     return message;
@@ -614,6 +617,7 @@ class QueuedRoleServerTransport final : public mcp::transport::ServerTransport {
 
   std::vector<RxMessage> inbound;
   std::vector<TxMessage> sent;
+  std::function<void(std::size_t)> before_receive;
   bool closed = false;
 
  private:
@@ -2331,6 +2335,131 @@ void test_server_peer_serves_role_generic_transport_receive_loop() {
           "server peer should dispatch transport notifications");
   require(notification_session == "peer-session",
           "server peer should pass transport session context");
+}
+
+void test_server_peer_serves_role_generic_transport_requests_concurrently() {
+  auto server = std::make_unique<mcp::server::Server>(make_server());
+
+  std::mutex gate_mutex;
+  std::condition_variable gate_cv;
+  bool slow_started = false;
+  bool slow_finished = false;
+  bool fast_started = false;
+  bool fast_started_while_slow_active = false;
+
+  const auto slow_added = server->tools().add(
+      mcp::protocol::ToolDefinition{
+          .name = "slow",
+          .description = "Slow test tool",
+          .input_schema = Json::object(),
+          .streaming = false,
+      },
+      [&](const mcp::server::ToolContext&)
+          -> mcp::core::Result<mcp::protocol::ToolResult> {
+        std::unique_lock lock(gate_mutex);
+        slow_started = true;
+        gate_cv.notify_all();
+        gate_cv.wait_for(lock, std::chrono::milliseconds(1000),
+                         [&] { return fast_started; });
+        slow_finished = true;
+        gate_cv.notify_all();
+        return mcp::protocol::ToolResult::text("slow");
+      });
+  require(slow_added.has_value(), "failed to register slow tool");
+
+  const auto fast_added = server->tools().add(
+      mcp::protocol::ToolDefinition{
+          .name = "fast",
+          .description = "Fast test tool",
+          .input_schema = Json::object(),
+          .streaming = false,
+      },
+      [&](const mcp::server::ToolContext&)
+          -> mcp::core::Result<mcp::protocol::ToolResult> {
+        std::lock_guard lock(gate_mutex);
+        fast_started_while_slow_active = slow_started && !slow_finished;
+        fast_started = true;
+        gate_cv.notify_all();
+        return mcp::protocol::ToolResult::text("fast");
+      });
+  require(fast_added.has_value(), "failed to register fast tool");
+
+  mcp::ServerPeer peer(std::move(server));
+  QueuedRoleServerTransport transport;
+  transport.inbound.push_back(mcp::protocol::JsonRpcRequest{
+      .method = mcp::protocol::InitializeMethod,
+      .params =
+          Json{{"protocolVersion", mcp::protocol::McpProtocolVersion},
+               {"capabilities", Json::object()},
+               {"clientInfo", Json{{"name", "role-client"}, {"version", "1"}}}},
+      .id = std::int64_t{699},
+  });
+  transport.inbound.push_back(mcp::protocol::JsonRpcNotification{
+      .method = "notifications/initialized",
+      .params = Json::object(),
+  });
+  transport.inbound.push_back(mcp::protocol::JsonRpcRequest{
+      .method = "tools/call",
+      .params = Json{{"name", "slow"}, {"arguments", Json::object()}},
+      .id = std::int64_t{700},
+  });
+  transport.inbound.push_back(mcp::protocol::JsonRpcRequest{
+      .method = "tools/call",
+      .params = Json{{"name", "fast"}, {"arguments", Json::object()}},
+      .id = std::int64_t{701},
+  });
+  transport.before_receive = [&](std::size_t index) {
+    if (index != 3) {
+      return;
+    }
+    std::unique_lock lock(gate_mutex);
+    gate_cv.wait_for(lock, std::chrono::milliseconds(1000),
+                     [&] { return slow_started; });
+  };
+
+  const auto served = peer.serve_transport(
+      transport, mcp::server::SessionContext{
+                     .session_id = "peer-concurrency-session",
+                     .remote_address = "role-generic-concurrency-test",
+                 });
+  require(served.has_value(),
+          "server peer role transport concurrency loop failed");
+  require(slow_started, "slow tools/call should start");
+  require(fast_started, "fast tools/call should start");
+  require(slow_finished, "slow tools/call should finish");
+  require(fast_started_while_slow_active,
+          "role-generic tools/call should run while slow call is active");
+
+  const auto find_response =
+      [&](std::int64_t id) -> const mcp::protocol::JsonRpcResponse* {
+    for (const auto& message : transport.sent) {
+      const auto* response =
+          std::get_if<mcp::protocol::JsonRpcResponse>(&message);
+      if (response == nullptr || !response->id.has_value()) {
+        continue;
+      }
+      const auto* response_id = std::get_if<std::int64_t>(&*response->id);
+      if (response_id != nullptr && *response_id == id) {
+        return response;
+      }
+    }
+    return nullptr;
+  };
+
+  const auto* slow_response = find_response(700);
+  const auto* fast_response = find_response(701);
+  require(slow_response != nullptr,
+          "server peer should send slow tools/call response");
+  require(fast_response != nullptr,
+          "server peer should send fast tools/call response");
+  require(slow_response->result.has_value(),
+          "slow tools/call response result missing");
+  require(fast_response->result.has_value(),
+          "fast tools/call response result missing");
+  require(slow_response->result->at("content").front().at("text") == "slow",
+          "slow tools/call response text mismatch");
+  require(fast_response->result->at("content").front().at("text") == "fast",
+          "fast tools/call response text mismatch");
 }
 
 void test_server_service_serves_role_generic_transport_receive_loop() {
@@ -7036,6 +7165,8 @@ int main() {
        test_service_lifecycle_facades_start_and_stop},
       {"server peer role-generic transport receive loop",
        test_server_peer_serves_role_generic_transport_receive_loop},
+      {"server peer role-generic transport requests concurrently",
+       test_server_peer_serves_role_generic_transport_requests_concurrently},
       {"server service role-generic transport receive loop",
        test_server_service_serves_role_generic_transport_receive_loop},
       {"server service native transport stop cancels loop",

--- a/tests/sdk/test_sdk.cpp
+++ b/tests/sdk/test_sdk.cpp
@@ -583,6 +583,22 @@ void enqueue_server_transport_lifecycle(
   transport.received.push_back(mcp::protocol::make_initialized_notification());
 }
 
+const mcp::protocol::JsonRpcResponse* find_response_by_id(
+    const std::vector<mcp::protocol::JsonRpcMessage>& sent, std::int64_t id) {
+  const mcp::protocol::RequestId request_id{id};
+  for (const auto& message : sent) {
+    const auto* response =
+        std::get_if<mcp::protocol::JsonRpcResponse>(&message);
+    if (response == nullptr || !response->id.has_value()) {
+      continue;
+    }
+    if (*response->id == request_id) {
+      return response;
+    }
+  }
+  return nullptr;
+}
+
 class BlockingServerContractTransport final
     : public mcp::transport::ServerTransport {
  public:
@@ -1407,8 +1423,7 @@ void test_server_peer_tool_discovery_dispatches_on_peer_boundary() {
       transport.sent.size() == 3,
       "server peer tool discovery should send initialize plus two responses");
 
-  const auto* list_response =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(1));
+  const auto* list_response = find_response_by_id(transport.sent, 10);
   require(list_response != nullptr, "tools/list response missing");
   require(list_response->result.has_value(), "tools/list result missing");
   require(list_response->result->at("tools").size() == 1,
@@ -1416,8 +1431,7 @@ void test_server_peer_tool_discovery_dispatches_on_peer_boundary() {
   require(list_response->result->at("tools").at(0).at("name") == "echo",
           "tools/list tool name mismatch");
 
-  const auto* get_response =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(2));
+  const auto* get_response = find_response_by_id(transport.sent, 11);
   require(get_response != nullptr, "tools/get response missing");
   require(get_response->result.has_value(), "tools/get result missing");
   require(get_response->result->at("name") == "echo",
@@ -1644,36 +1658,31 @@ void test_server_peer_prompt_resource_dispatches_on_peer_boundary() {
   require(transport.sent.size() == 6,
           "server peer prompt/resource dispatch response count mismatch");
 
-  const auto* prompts_list =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(1));
+  const auto* prompts_list = find_response_by_id(transport.sent, 20);
   require(prompts_list != nullptr, "prompts/list response missing");
   require(
       prompts_list->result->at("prompts").at(0).at("name") == "session-summary",
       "prompts/list prompt name mismatch");
 
-  const auto* prompt_get =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(2));
+  const auto* prompt_get = find_response_by_id(transport.sent, 21);
   require(prompt_get != nullptr, "prompts/get response missing");
   require(prompt_get->result->at("messages").at(0).at("content").at("text") ==
               "peer-session:hello",
           "prompts/get should preserve session context");
 
-  const auto* resources_list =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(3));
+  const auto* resources_list = find_response_by_id(transport.sent, 22);
   require(resources_list != nullptr, "resources/list response missing");
   require(resources_list->result->at("resources").at(0).at("uri") ==
               "file:///tmp/session.txt",
           "resources/list uri mismatch");
 
-  const auto* resources_read =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(4));
+  const auto* resources_read = find_response_by_id(transport.sent, 23);
   require(resources_read != nullptr, "resources/read response missing");
   require(resources_read->result->at("contents").at(0).at("text") ==
               "peer-session:file:///tmp/session.txt:intro",
           "resources/read should preserve session context and params");
 
-  const auto* templates_list =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(5));
+  const auto* templates_list = find_response_by_id(transport.sent, 24);
   require(templates_list != nullptr,
           "resources/templates/list response missing");
   require(
@@ -1774,20 +1783,17 @@ void test_server_peer_handler_requests_dispatch_on_peer_boundary() {
   require(transport.sent.size() == 4,
           "server peer handler request response count mismatch");
 
-  const auto* completion =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(1));
+  const auto* completion = find_response_by_id(transport.sent, 30);
   require(completion != nullptr, "completion response missing");
   require(completion->result->at("completion") == "peer-session:hello",
           "completion result mismatch");
 
-  const auto* sampling =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(2));
+  const auto* sampling = find_response_by_id(transport.sent, 31);
   require(sampling != nullptr, "sampling response missing");
   require(sampling->result->at("sampled") == "peer-session:1",
           "sampling result mismatch");
 
-  const auto* logging =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(3));
+  const auto* logging = find_response_by_id(transport.sent, 32);
   require(logging != nullptr, "logging response missing");
   require(logging->result.has_value(), "logging result missing");
   require(logged_level == "debug:logging level changed",
@@ -2021,31 +2027,27 @@ void test_server_peer_task_handlers_dispatch_on_peer_boundary() {
   require(transport.sent.size() == 5,
           "server peer task handler response count mismatch");
 
-  const auto* list_response =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(1));
+  const auto* list_response = find_response_by_id(transport.sent, 40);
   require(list_response != nullptr, "tasks/list response missing");
   require(list_response->result->at("tasks").at(0).at("taskId") ==
               "peer-task-session-listed",
           "tasks/list result mismatch");
 
-  const auto* get_response =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(2));
+  const auto* get_response = find_response_by_id(transport.sent, 41);
   require(get_response != nullptr, "tasks/get response missing");
   require(get_response->result->at("taskId") == "peer-task-session-task-a",
           "tasks/get should preserve session context");
   require(get_response->result->at("status") == "completed",
           "tasks/get status mismatch");
 
-  const auto* cancel_response =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(3));
+  const auto* cancel_response = find_response_by_id(transport.sent, 42);
   require(cancel_response != nullptr, "tasks/cancel response missing");
   require(cancel_response->result->at("taskId") == "task-b",
           "tasks/cancel task id mismatch");
   require(cancel_response->result->at("status") == "cancelled",
           "tasks/cancel status mismatch");
 
-  const auto* result_response =
-      std::get_if<mcp::protocol::JsonRpcResponse>(&transport.sent.at(4));
+  const auto* result_response = find_response_by_id(transport.sent, 43);
   require(result_response != nullptr, "tasks/result response missing");
   require(result_response->result->at("taskId") == "task-c",
           "tasks/result task id mismatch");

--- a/tests/transport/test_http_transport.cpp
+++ b/tests/transport/test_http_transport.cpp
@@ -34,10 +34,12 @@
 #endif
 
 #include "cxxmcp/client/http_transport.hpp"
+#include "cxxmcp/peer.hpp"
 #include "cxxmcp/protocol/serialization.hpp"
 #include "cxxmcp/server/http_transport.hpp"
 #include "cxxmcp/server/peer.hpp"
 #include "cxxmcp/server/server.hpp"
+#include "cxxmcp/service.hpp"
 #include "cxxmcp/transport/http_transport.hpp"
 #include "httplib.h"
 
@@ -339,6 +341,45 @@ std::string initialize_http_session(int port, const std::string& path,
   require(initialize_response->has_header("Mcp-Session-Id"),
           "initialize should return a session id");
   return initialize_response->get_header_value("Mcp-Session-Id");
+}
+
+std::string initialize_canonical_http_session(int port, const std::string& path,
+                                              std::int64_t id = 1) {
+  const auto initialize_body =
+      serialize_test_request(mcp::protocol::JsonRpcRequest{
+          .method = mcp::protocol::InitializeMethod,
+          .params =
+              Json{
+                  {"protocolVersion", mcp::protocol::McpProtocolVersion},
+                  {"capabilities", Json::object()},
+                  {"clientInfo",
+                   Json{{"name", "canonical-http-test"}, {"version", "1"}}},
+              },
+          .id = id,
+      });
+
+  for (int attempt = 0; attempt < 100; ++attempt) {
+    httplib::Client http_client("127.0.0.1", port);
+    http_client.set_connection_timeout(0, 100000);
+    http_client.set_read_timeout(2, 0);
+    http_client.set_write_timeout(2, 0);
+    const auto initialize_response =
+        http_client.Post(path,
+                         httplib::Headers{
+                             {"Accept", "application/json, text/event-stream"},
+                             {"Content-Type", "application/json"},
+                             {"Mcp-Method", mcp::protocol::InitializeMethod},
+                         },
+                         initialize_body, "application/json");
+    if (initialize_response && initialize_response->status >= 200 &&
+        initialize_response->status < 300 &&
+        initialize_response->has_header("Mcp-Session-Id")) {
+      return initialize_response->get_header_value("Mcp-Session-Id");
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  throw std::runtime_error("canonical initialize should create a session");
 }
 
 httplib::Result post_initialized_notification(int port, const std::string& path,
@@ -3291,6 +3332,180 @@ void test_server_http_transport_runs_tools_calls_concurrently() {
   server_transport.transport().stop();
 }
 
+void test_canonical_streamable_http_server_peer_runs_tools_calls_concurrently() {
+  constexpr int kPort = 40264;
+  const std::string kPath = "/canonical-mcp";
+
+  std::mutex gate_mutex;
+  std::condition_variable gate_cv;
+  bool slow_started = false;
+  bool slow_finished = false;
+  bool fast_started = false;
+  bool fast_started_while_slow_active = false;
+  bool second_session_initialized_while_slow_active = false;
+
+  auto server =
+      std::make_unique<mcp::server::Server>(mcp::server::ServerOptions{});
+  const auto slow_added = server->tools().add(
+      mcp::protocol::ToolDefinition{
+          .name = "slow",
+          .description = "Slow canonical HTTP tool",
+          .input_schema = Json::object(),
+          .streaming = false,
+      },
+      [&](const mcp::server::ToolContext&)
+          -> mcp::core::Result<mcp::protocol::ToolResult> {
+        std::unique_lock lock(gate_mutex);
+        slow_started = true;
+        gate_cv.notify_all();
+        gate_cv.wait_for(lock, std::chrono::milliseconds(1500),
+                         [&] { return fast_started; });
+        slow_finished = true;
+        gate_cv.notify_all();
+        return mcp::protocol::ToolResult::text("slow");
+      });
+  require(slow_added.has_value(), "failed to register canonical slow tool");
+
+  const auto fast_added = server->tools().add(
+      mcp::protocol::ToolDefinition{
+          .name = "fast",
+          .description = "Fast canonical HTTP tool",
+          .input_schema = Json::object(),
+          .streaming = false,
+      },
+      [&](const mcp::server::ToolContext&)
+          -> mcp::core::Result<mcp::protocol::ToolResult> {
+        std::lock_guard lock(gate_mutex);
+        fast_started_while_slow_active = slow_started && !slow_finished;
+        fast_started = true;
+        gate_cv.notify_all();
+        return mcp::protocol::ToolResult::text("fast");
+      });
+  require(fast_added.has_value(), "failed to register canonical fast tool");
+
+  auto transport =
+      std::make_unique<mcp::transport::StreamableHttpServerTransport>(
+          mcp::transport::StreamableHttpServerTransportOptions{
+              .listen_host = "127.0.0.1",
+              .listen_port = kPort,
+              .path = kPath,
+          });
+  auto* transport_ptr = transport.get();
+  auto running =
+      mcp::serve(mcp::ServerPeer(std::move(server)), std::move(transport));
+  require(running.has_value(), "canonical HTTP ServerPeer should start");
+  transport_ptr->wait_until_ready();
+
+  const auto session_id = initialize_canonical_http_session(kPort, kPath, 84);
+  require_initialized_notification(kPort, kPath, session_id);
+
+  auto post_tool_call = [&](std::string name, std::int64_t id) {
+    httplib::Client http_client("127.0.0.1", kPort);
+    http_client.set_read_timeout(std::chrono::milliseconds(3000));
+    return http_client.Post(
+        kPath,
+        httplib::Headers{
+            {"Accept", "application/json, text/event-stream"},
+            {"Content-Type", "application/json"},
+            {"MCP-Protocol-Version", mcp::protocol::McpProtocolVersion},
+            {"Mcp-Session-Id", session_id},
+            {"Mcp-Method", mcp::protocol::ToolsCallMethod},
+            {"Mcp-Name", name},
+        },
+        serialize_test_request(mcp::protocol::JsonRpcRequest{
+            .method = mcp::protocol::ToolsCallMethod,
+            .params = Json{{"name", name}, {"arguments", Json::object()}},
+            .id = id,
+        }),
+        "application/json");
+  };
+
+  std::optional<httplib::Result> slow_response;
+  std::exception_ptr slow_failure;
+  std::thread slow_thread([&]() {
+    try {
+      slow_response = post_tool_call("slow", 85);
+    } catch (...) {
+      slow_failure = std::current_exception();
+    }
+  });
+
+  bool observed_slow = false;
+  {
+    std::unique_lock lock(gate_mutex);
+    observed_slow = gate_cv.wait_for(lock, std::chrono::milliseconds(1000),
+                                     [&] { return slow_started; });
+  }
+
+  std::optional<std::string> second_session_id;
+  std::exception_ptr initialize_failure;
+  std::thread initialize_thread([&]() {
+    try {
+      auto initialized_session =
+          initialize_canonical_http_session(kPort, kPath, 87);
+      {
+        std::lock_guard lock(gate_mutex);
+        second_session_initialized_while_slow_active =
+            slow_started && !slow_finished;
+      }
+      second_session_id = std::move(initialized_session);
+    } catch (...) {
+      initialize_failure = std::current_exception();
+    }
+  });
+
+  if (initialize_thread.joinable()) {
+    initialize_thread.join();
+  }
+
+  std::optional<httplib::Result> fast_response;
+  std::exception_ptr fast_failure;
+  try {
+    fast_response = post_tool_call("fast", 86);
+  } catch (...) {
+    fast_failure = std::current_exception();
+  }
+
+  if (slow_thread.joinable()) {
+    slow_thread.join();
+  }
+  if (fast_failure) {
+    std::rethrow_exception(fast_failure);
+  }
+  if (slow_failure) {
+    std::rethrow_exception(slow_failure);
+  }
+  if (initialize_failure) {
+    std::rethrow_exception(initialize_failure);
+  }
+
+  require(observed_slow, "canonical slow tools/call should reach handler");
+  require(second_session_id.has_value(),
+          "canonical second HTTP session initialize should return");
+  require(
+      second_session_initialized_while_slow_active,
+      "canonical HTTP initialize should complete while slow call is active");
+  require(fast_response.has_value() && static_cast<bool>(*fast_response),
+          "canonical fast tools/call should return");
+  require((*fast_response)->status == 200,
+          "canonical fast tools/call response status mismatch");
+  const auto parsed_fast =
+      mcp::protocol::parse_response((*fast_response)->body);
+  require(parsed_fast.has_value(),
+          "canonical fast tools/call response should parse");
+  require(parsed_fast->result.has_value(),
+          "canonical fast tools/call should contain a result");
+  require(fast_started_while_slow_active,
+          "canonical HTTP tools/call should run while slow call is active");
+  require(slow_response.has_value() && static_cast<bool>(*slow_response),
+          "canonical slow tools/call should return");
+  require((*slow_response)->status == 200,
+          "canonical slow tools/call response status mismatch");
+
+  const auto stopped = running->stop();
+  require(stopped.has_value(), "canonical HTTP ServerPeer should stop");
+}
+
 void test_server_http_transport_rejects_invalid_required_headers() {
   constexpr int kPort = 40236;
   const std::string kPath = "/mcp";
@@ -6122,6 +6337,8 @@ int main() {
        test_server_http_transport_accepts_standard_post_without_custom_headers},
       {"server http transport runs tools/call concurrently",
        test_server_http_transport_runs_tools_calls_concurrently},
+      {"canonical streamable http ServerPeer runs tools/call concurrently",
+       test_canonical_streamable_http_server_peer_runs_tools_calls_concurrently},
       {"server http transport rejects invalid required headers",
        test_server_http_transport_rejects_invalid_required_headers},
       {"server http transport can request client",


### PR DESCRIPTION
## Summary
- fix `Peer<RoleServer>::serve_transport()` so post-initialization requests are dispatched concurrently instead of blocking the receive loop
- serialize transport sends while allowing slow `tools/call` handlers to run alongside later requests
- add regression coverage for the canonical `ServerPeer` role-generic path and `mcp::serve(ServerPeer, StreamableHttpServerTransport)` HTTP path

## Root cause
PR #56 fixed and tested lower-level/legacy transport callback paths, but missed the canonical user path:

```cpp
mcp::serve(mcp::ServerPeer(...), transport)
```

In v1.2.3, that path still did `receive -> dispatch -> send` sequentially. A slow `tools/call` therefore blocked the receive loop, so later tool calls and even a new Streamable HTTP session initialize could not be handled until the slow call finished.

## Validation
Current branch:
- `pwsh -NoProfile -File scripts\format.ps1 -Check`
- `git diff --check`
- `cmake --build build-issue43 --target mcp_client_server_tests mcp_http_transport_tests --config Debug`
- `ctest --test-dir build-issue43 -R "^client_server$" --output-on-failure --timeout 600`
- `ctest --test-dir build-issue43 -R "^http_transport$" --output-on-failure --timeout 900`

A/B against v1.2.3 with only the new regression tests applied:
- `client_server` fails at `role-generic tools/call should run while slow call is active`
- `http_transport` fails at `canonical HTTP initialize should complete while slow call is active`

Fixes #51