### PR TITLE
Add README CMake option drift check

### DIFF
--- a/.github/workflows/release-gates.yml
+++ b/.github/workflows/release-gates.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Check package recipe sync
         run: python scripts/check_package_recipe_sync.py --source .
 
+      - name: Check README CMake option drift
+        run: python scripts/check_readme_cmake_options.py --source .
+
       - name: Self-test release artifact verifier
         run: python scripts/selftest_release_artifacts.py
 

--- a/README.md
+++ b/README.md
@@ -119,15 +119,21 @@ Package managers: `conanfile.py` (Conan 2), `packaging/vcpkg/ports/cxxmcp-sdk` (
 | Option | Default | Description |
 |---|---:|---|
 | `CXXMCP_BUILD_SDK` | `ON` | Build the aggregate SDK layer (protocol + client + server) |
+| `CXXMCP_BUILD_PROTOCOL` | `ON` | Build the MCP protocol library |
 | `CXXMCP_BUILD_CLIENT` | `OFF` | Build the MCP client library |
 | `CXXMCP_BUILD_SERVER` | `OFF` | Build the MCP server library |
 | `CXXMCP_BUILD_EXAMPLES` | `OFF` | Build example executables |
 | `CXXMCP_BUILD_TESTS` | `BUILD_TESTING` | Build tests |
 | `CXXMCP_BUILD_BENCHMARKS` | `OFF` | Build benchmark executables |
+| `CXXMCP_BUILD_DOCS` | `OFF` | Build Doxygen API documentation |
 | `CXXMCP_ENABLE_HTTP` | `OFF` | Build HTTP/SSE transport (uses bundled `cpp-httplib` unless `CXXMCP_USE_SYSTEM_DEPS=ON`) |
 | `CXXMCP_ENABLE_OPENSSL` | `OFF` | Enable OpenSSL-backed HTTP/WebSocket TLS support |
 | `CXXMCP_ENABLE_AUTH` | `OFF` | Build the optional OAuth 2.1 / DPoP auth target |
+| `CXXMCP_AUTH_CRYPTO` | `NONE` | Optional auth crypto backend (`NONE` or `OpenSSL`; requires `CXXMCP_ENABLE_AUTH=ON`) |
 | `CXXMCP_ENABLE_WEBSOCKET` | `OFF` | Build WebSocket transport (requires `CXXMCP_ENABLE_HTTP`) |
+| `CXXMCP_USE_SYSTEM_DEPS` | `OFF` | Use package-manager dependencies instead of bundled header-only SDK dependencies |
+| `CXXMCP_SDK_CXX_STANDARD` | `17` | Minimum C++ standard required by exported SDK targets (`17`, `20`, `23`, or `26`) |
+| `CXXMCP_MSVC_RUNTIME_LIBRARY` | empty | Optional MSVC runtime library override; empty keeps the toolchain default |
 
 ## Package Targets
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -119,15 +119,21 @@ client 路径，还需要加上 `-DCXXMCP_ENABLE_HTTP=ON`。
 | Option | Default | 说明 |
 |---|---:|---|
 | `CXXMCP_BUILD_SDK` | `ON` | 构建聚合 SDK 层（protocol + client + server） |
+| `CXXMCP_BUILD_PROTOCOL` | `ON` | 构建 MCP protocol library |
 | `CXXMCP_BUILD_CLIENT` | `OFF` | 构建 MCP client library |
 | `CXXMCP_BUILD_SERVER` | `OFF` | 构建 MCP server library |
 | `CXXMCP_BUILD_EXAMPLES` | `OFF` | 构建示例 |
 | `CXXMCP_BUILD_TESTS` | `BUILD_TESTING` | 构建测试 |
 | `CXXMCP_BUILD_BENCHMARKS` | `OFF` | 构建 benchmark 可执行文件 |
+| `CXXMCP_BUILD_DOCS` | `OFF` | 构建 Doxygen API 文档 |
 | `CXXMCP_ENABLE_HTTP` | `OFF` | 构建 HTTP/SSE transport（默认使用 bundled `cpp-httplib`，`CXXMCP_USE_SYSTEM_DEPS=ON` 时使用系统包） |
 | `CXXMCP_ENABLE_OPENSSL` | `OFF` | 启用 OpenSSL-backed HTTP/WebSocket TLS 支持 |
-| `CXXMCP_ENABLE_WEBSOCKET` | `OFF` | 构建 WebSocket transport（需要 `CXXMCP_ENABLE_HTTP`） |
 | `CXXMCP_ENABLE_AUTH` | `OFF` | 构建可选 OAuth 2.1 / DPoP auth target |
+| `CXXMCP_AUTH_CRYPTO` | `NONE` | 可选 auth crypto backend（`NONE` 或 `OpenSSL`；需要 `CXXMCP_ENABLE_AUTH=ON`） |
+| `CXXMCP_ENABLE_WEBSOCKET` | `OFF` | 构建 WebSocket transport（需要 `CXXMCP_ENABLE_HTTP`） |
+| `CXXMCP_USE_SYSTEM_DEPS` | `OFF` | 使用包管理器依赖，而不是 bundled header-only SDK 依赖 |
+| `CXXMCP_SDK_CXX_STANDARD` | `17` | exported SDK targets 要求的最低 C++ 标准（`17`、`20`、`23` 或 `26`） |
+| `CXXMCP_MSVC_RUNTIME_LIBRARY` | empty | 可选 MSVC runtime library 覆盖；留空表示沿用 toolchain 默认值 |
 
 ## Package Targets
 

--- a/scripts/check_readme_cmake_options.py
+++ b/scripts/check_readme_cmake_options.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Validate README CMake option tables against public CMake cache options."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+
+
+CMAKE_OPTION_PATTERNS = [
+    re.compile(r"\bcxxmcp_build_option\s*\(\s*(CXXMCP_[A-Z0-9_]+)"),
+    re.compile(r"\boption\s*\(\s*(CXXMCP_[A-Z0-9_]+)"),
+    re.compile(
+        r"\bset\s*\(\s*(CXXMCP_[A-Z0-9_]+)\s+.*?\bCACHE\s+"
+        r"(?:BOOL|FILEPATH|PATH|STRING)\b",
+        re.DOTALL,
+    ),
+]
+
+README_FILES = [
+    "README.md",
+    "README_zh.md",
+]
+
+
+def read_text(path: Path) -> str:
+    if not path.is_file():
+        raise SystemExit(f"README CMake option check failed: missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def public_cmake_options(source: Path) -> list[str]:
+    text = read_text(source / "CMakeLists.txt")
+    options: set[str] = set()
+    for pattern in CMAKE_OPTION_PATTERNS:
+        options.update(match.group(1) for match in pattern.finditer(text))
+    return sorted(options)
+
+
+def cmake_options_section(text: str, path: Path) -> str:
+    match = re.search(
+        r"^## CMake Options\s*$([\s\S]*?)(?=^##\s|\Z)",
+        text,
+        re.MULTILINE,
+    )
+    if not match:
+        raise SystemExit(
+            f"README CMake option check failed: {path} has no "
+            "`## CMake Options` section"
+        )
+    return match.group(1)
+
+
+def readme_table_options(source: Path, relative: str) -> set[str]:
+    path = source / relative
+    section = cmake_options_section(read_text(path), path)
+    return set(re.findall(r"\|\s*`(CXXMCP_[A-Z0-9_]+)`\s*\|", section))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", default=".", help="repository source root")
+    args = parser.parse_args()
+
+    source = Path(args.source).resolve()
+    expected = public_cmake_options(source)
+
+    errors: list[str] = []
+    for relative in README_FILES:
+        documented = readme_table_options(source, relative)
+        missing = [option for option in expected if option not in documented]
+        extra = sorted(documented - set(expected))
+        if missing:
+            errors.append(
+                f"{relative}: missing CMake option(s): {', '.join(missing)}"
+            )
+        if extra:
+            errors.append(
+                f"{relative}: documents unknown CMake option(s): {', '.join(extra)}"
+            )
+
+    if errors:
+        raise SystemExit(
+            "README CMake option check failed:\n" + "\n".join(errors)
+        )
+
+    print(
+        "README CMake option check passed "
+        f"({len(expected)} public option(s), {len(README_FILES)} README files)"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary\n\n- document missing public CMake options in README.md and README_zh.md\n- add a README CMake option drift checker for public CMake cache/build options\n- wire the checker into the release-gates source-style job\n\n## Validation\n\n- scripts\\format.ps1 -Check\n- python scripts\\check_readme_cmake_options.py --source .\n- python scripts\\check_source_markers.py --source .\n- python scripts\\check_package_recipe_sync.py --source .\n- git diff --check\n\nCloses #58