### PR TITLE
test: cover request-level cancellation notifications

### DIFF
--- a/tests/client_server/test_client_server.cpp
+++ b/tests/client_server/test_client_server.cpp
@@ -2462,6 +2462,76 @@ void test_server_peer_serves_role_generic_transport_requests_concurrently() {
           "fast tools/call response text mismatch");
 }
 
+void test_server_peer_receive_loop_cancelled_notification_cancels_tool() {
+  auto server = std::make_unique<mcp::server::Server>(make_server());
+  std::atomic_bool handler_started{false};
+  std::atomic_bool handler_observed_cancel{false};
+  const auto added = server->tools().add(
+      mcp::protocol::ToolDefinition{
+          .name = "cancellable",
+          .input_schema = Json::object(),
+      },
+      [&](const mcp::server::ToolContext& context)
+          -> mcp::core::Result<mcp::protocol::ToolResult> {
+        handler_started.store(true);
+        wait_until([&] { return context.cancelled(); },
+                   "receive-loop tool should observe cancellation");
+        handler_observed_cancel.store(true);
+        return mcp::protocol::ToolResult::text("cancelled");
+      });
+  require(added.has_value(),
+          "failed to register receive-loop cancellable tool");
+
+  mcp::ServerPeer peer(std::move(server));
+  QueuedRoleServerTransport transport;
+  transport.inbound.push_back(mcp::protocol::JsonRpcRequest{
+      .method = mcp::protocol::InitializeMethod,
+      .params =
+          Json{{"protocolVersion", mcp::protocol::McpProtocolVersion},
+               {"capabilities", Json::object()},
+               {"clientInfo", Json{{"name", "role-client"}, {"version", "1"}}}},
+      .id = std::int64_t{720},
+  });
+  transport.inbound.push_back(mcp::protocol::JsonRpcNotification{
+      .method = "notifications/initialized",
+      .params = Json::object(),
+  });
+  transport.inbound.push_back(mcp::protocol::JsonRpcRequest{
+      .method = mcp::protocol::ToolsCallMethod,
+      .params = Json{{"name", "cancellable"}, {"arguments", Json::object()}},
+      .id = std::int64_t{721},
+  });
+  transport.inbound.push_back(mcp::protocol::JsonRpcNotification{
+      .method = mcp::protocol::CancelledNotificationMethod,
+      .params = Json{{"requestId", 721}, {"reason", "client timeout"}},
+  });
+  transport.before_receive = [&](std::size_t index) {
+    if (index == 3) {
+      wait_until([&] { return handler_started.load(); },
+                 "receive-loop tool should start before cancellation");
+    }
+  };
+
+  const auto served =
+      peer.serve_transport(transport, mcp::server::SessionContext{
+                                          .session_id = "peer-cancel-session",
+                                          .remote_address = "role-cancel-test",
+                                      });
+  require(served.has_value(), "server peer receive loop cancel should succeed");
+  require(handler_observed_cancel.load(),
+          "receive-loop tool should observe cancelled notification");
+
+  bool saw_tool_response = false;
+  for (const auto& sent : transport.sent) {
+    const auto* response = std::get_if<mcp::protocol::JsonRpcResponse>(&sent);
+    if (response != nullptr && response->id.has_value() &&
+        *response->id == mcp::protocol::RequestId{std::int64_t{721}}) {
+      saw_tool_response = true;
+    }
+  }
+  require(saw_tool_response, "receive-loop tool response should be sent");
+}
+
 void test_server_service_serves_role_generic_transport_receive_loop() {
   auto server = std::make_unique<mcp::server::Server>(make_server());
   int raw_notifications = 0;
@@ -7165,6 +7235,8 @@ int main() {
        test_service_lifecycle_facades_start_and_stop},
       {"server peer role-generic transport receive loop",
        test_server_peer_serves_role_generic_transport_receive_loop},
+      {"server peer receive-loop cancelled notification cancels tool",
+       test_server_peer_receive_loop_cancelled_notification_cancels_tool},
       {"server peer role-generic transport requests concurrently",
        test_server_peer_serves_role_generic_transport_requests_concurrently},
       {"server service role-generic transport receive loop",

--- a/tests/transport/test_http_transport.cpp
+++ b/tests/transport/test_http_transport.cpp
@@ -3597,6 +3597,152 @@ void test_canonical_streamable_http_server_peer_runs_tools_calls_concurrently() 
   require(stopped.has_value(), "canonical HTTP ServerPeer should stop");
 }
 
+void test_canonical_streamable_http_server_peer_cancelled_notification_cancels_tool() {
+  constexpr int kPort = 40268;
+  const std::string kPath = "/canonical-cancel-mcp";
+
+  std::mutex gate_mutex;
+  std::condition_variable gate_cv;
+  bool tool_started = false;
+  bool tool_cancelled = false;
+
+  auto server =
+      std::make_unique<mcp::server::Server>(mcp::server::ServerOptions{});
+  const auto cancellable_added = server->tools().add(
+      mcp::protocol::ToolDefinition{
+          .name = "cancellable",
+          .description = "Cancellable canonical HTTP tool",
+          .input_schema = Json::object(),
+          .streaming = false,
+      },
+      [&](const mcp::server::ToolContext& context)
+          -> mcp::core::Result<mcp::protocol::ToolResult> {
+        {
+          std::lock_guard lock(gate_mutex);
+          tool_started = true;
+        }
+        gate_cv.notify_all();
+
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::milliseconds(3000);
+        bool observed_cancel = false;
+        while (std::chrono::steady_clock::now() < deadline) {
+          if (context.cancelled()) {
+            observed_cancel = true;
+            break;
+          }
+          std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+
+        {
+          std::lock_guard lock(gate_mutex);
+          tool_cancelled = observed_cancel;
+        }
+        gate_cv.notify_all();
+        return mcp::protocol::ToolResult::text(observed_cancel ? "cancelled"
+                                                               : "completed");
+      });
+  require(cancellable_added.has_value(),
+          "failed to register canonical cancellable tool");
+
+  auto transport =
+      std::make_unique<mcp::transport::StreamableHttpServerTransport>(
+          mcp::transport::StreamableHttpServerTransportOptions{
+              .listen_host = "127.0.0.1",
+              .listen_port = kPort,
+              .path = kPath,
+          });
+  auto* transport_ptr = transport.get();
+  auto running =
+      mcp::serve(mcp::ServerPeer(std::move(server)), std::move(transport));
+  require(running.has_value(), "canonical HTTP cancel server should start");
+  transport_ptr->wait_until_ready();
+
+  const auto session_id = initialize_canonical_http_session(kPort, kPath, 141);
+  require_initialized_notification(kPort, kPath, session_id);
+
+  std::optional<httplib::Result> tool_response;
+  std::exception_ptr tool_failure;
+  std::thread tool_thread([&]() {
+    try {
+      httplib::Client http_client("127.0.0.1", kPort);
+      http_client.set_read_timeout(std::chrono::milliseconds(5000));
+      tool_response = http_client.Post(
+          kPath,
+          httplib::Headers{
+              {"Accept", "application/json, text/event-stream"},
+              {"Content-Type", "application/json"},
+              {"MCP-Protocol-Version", mcp::protocol::McpProtocolVersion},
+              {"Mcp-Session-Id", session_id},
+              {"Mcp-Method", mcp::protocol::ToolsCallMethod},
+              {"Mcp-Name", "cancellable"},
+          },
+          serialize_test_request(mcp::protocol::JsonRpcRequest{
+              .method = mcp::protocol::ToolsCallMethod,
+              .params =
+                  Json{{"name", "cancellable"}, {"arguments", Json::object()}},
+              .id = std::int64_t{142},
+          }),
+          "application/json");
+    } catch (...) {
+      tool_failure = std::current_exception();
+    }
+  });
+
+  {
+    std::unique_lock lock(gate_mutex);
+    require(gate_cv.wait_for(lock, std::chrono::milliseconds(1000),
+                             [&] { return tool_started; }),
+            "canonical cancellable tool should start");
+  }
+
+  httplib::Client cancel_client("127.0.0.1", kPort);
+  const auto cancel_response = cancel_client.Post(
+      kPath,
+      httplib::Headers{
+          {"Accept", "application/json, text/event-stream"},
+          {"Content-Type", "application/json"},
+          {"MCP-Protocol-Version", mcp::protocol::McpProtocolVersion},
+          {"Mcp-Session-Id", session_id},
+          {"Mcp-Method", mcp::protocol::CancelledNotificationMethod},
+      },
+      serialize_test_notification(mcp::protocol::JsonRpcNotification{
+          .method = mcp::protocol::CancelledNotificationMethod,
+          .params = Json{{"requestId", 142}, {"reason", "client timeout"}},
+      }),
+      "application/json");
+  const bool cancel_returned = static_cast<bool>(cancel_response);
+  const int cancel_status = cancel_returned ? cancel_response->status : 0;
+
+  bool observed_tool_cancel = false;
+  {
+    std::unique_lock lock(gate_mutex);
+    observed_tool_cancel = gate_cv.wait_for(
+        lock, std::chrono::milliseconds(1000), [&] { return tool_cancelled; });
+  }
+
+  if (tool_thread.joinable()) {
+    tool_thread.join();
+  }
+  if (tool_failure) {
+    std::rethrow_exception(tool_failure);
+  }
+
+  require(cancel_returned,
+          "canonical HTTP cancelled notification should return");
+  require(cancel_status == 202,
+          "canonical HTTP cancelled notification status mismatch");
+  require(observed_tool_cancel,
+          "canonical cancellable tool should observe notification cancel");
+  require(tool_response.has_value() && static_cast<bool>(*tool_response),
+          "canonical cancellable tool response should return");
+  require((*tool_response)->status == 200,
+          "canonical cancellable tool response status mismatch");
+
+  const auto stopped = running->stop();
+  require(stopped.has_value(), "canonical HTTP cancel server should stop");
+}
+
 void test_canonical_streamable_http_server_peer_routes_duplicate_ids_by_session() {
   constexpr int kPort = 40265;
   const std::string kPath = "/canonical-duplicate-id-mcp";
@@ -6775,6 +6921,8 @@ int main() {
        test_server_http_transport_runs_tools_calls_concurrently},
       {"canonical streamable http ServerPeer runs tools/call concurrently",
        test_canonical_streamable_http_server_peer_runs_tools_calls_concurrently},
+      {"canonical streamable http ServerPeer cancellation cancels tool",
+       test_canonical_streamable_http_server_peer_cancelled_notification_cancels_tool},
       {"canonical streamable http ServerPeer routes duplicate ids by session",
        test_canonical_streamable_http_server_peer_routes_duplicate_ids_by_session},
       {"streamable http ClientPeer calls tools concurrently",


### PR DESCRIPTION
## Summary
- add HTTP request-level notifications/cancelled regression for ServerPeer tools/call
- add receive-loop regression covering stdio/native transport cancellation handling
- keep SDK C++17 baseline unchanged

## Verification
- cmake --build D:/repo/cxxmcp/out/build/cxx17-agent -- -k 0
- ctest --test-dir D:/repo/cxxmcp/out/build/cxx17-agent -R "^(http_transport|client_server|sdk|stdio_transport)$" --output-on-failure
- pwsh -NoProfile -File D:/repo/cxxmcp/scripts/format.ps1 -Check

Refs #67